### PR TITLE
warning if exchange for CSV export is not in found in CCTX list

### DIFF
--- a/src/book.py
+++ b/src/book.py
@@ -856,6 +856,24 @@ class Book:
 
             log.info("Reading file from exchange %s at %s", exchange, file_path)
             read_file(file_path)
+
+            cctx_mapping = {
+                "binance": "binance",
+                "binance_v2": "binance",
+                "coinbase": "coinbasepro",
+                "coinbase_pro": "coinbasepro",
+                "kraken_ledgers_old": "kraken",
+                "kraken_ledgers": "kraken",
+                "kraken_trades": "kraken",
+                "bitpanda_pro_trades": "bitpanda",
+            }
+            api = cctx_mapping.get(exchange)
+
+            if api not in config.EXCHANGES:
+                log.warning(
+                    f"Exchange `{api}` not found in EXCHANGES API list in config.py. "
+                    "Consider adding it to obtain more accurate price data."
+                )
         else:
             log.warning(
                 f"Unable to detect the exchange of file `{file_path}`. "


### PR DESCRIPTION
Hi @scientes,

I added a warning if the exchange of the CSV export is not found in the CCTX list (EXCHANGES in config.py).
What do you think of it? Let me know if it requires any changes.

Resolves comment https://github.com/provinzio/CoinTaxman/pull/16#issuecomment-992427782